### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "grunt-node-gyp",
-	"version": "0.4.1",
+	"name": "grunt-nw-gyp",
+	"version": "0.5.0",
 	"author": "Jakob Krigovsky <jakob.krigovsky@gmail.com>",
-	"description": "Run node-gyp commands from Grunt.",
+	"description": "Run nw-gyp commands from Grunt.",
 	"contributors": [
 		{
 			"name": "Jakob Krigovsky",
@@ -21,18 +21,18 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/SonicHedgehog/grunt-node-gyp.git"
+		"url": "https://github.com/MiniGod/grunt-nw-gyp.git"
 	},
 	"keywords": [
 		"gruntplugin",
-		"node-gyp",
+		"nw-gyp",
 		"build"
 	],
 	"dependencies": {
-		"node-gyp": "1.x"
+		"nw-gyp": "^0.12.4"
 	},
 	"peerDependencies": {
-		"grunt": "~0.4"
+		"grunt": ">=0.4.0"
 	},
 	"devDependencies": {
 		"chai": "1.7.x",


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
